### PR TITLE
Typo fix (s/of/on)

### DIFF
--- a/src/epub/text/chapter-10.xhtml
+++ b/src/epub/text/chapter-10.xhtml
@@ -21,7 +21,7 @@
 			<p>This theory was received in polite silence. I saw Poirot edge up to the lawyer, and speak to him in a confidential undertone. They moved aside into the embrasure of the window. I joined them⁠—then hesitated.</p>
 			<p>“Perhaps I’m intruding,” I said.</p>
 			<p>“Not at all,” cried Poirot heartily. “You and I, <abbr>M.</abbr> le docteur, we investigate this affair side by side. Without you I should be lost. I desire a little information from the good <abbr>Mr.</abbr> Hammond.”</p>
-			<p>“You are acting of behalf of Captain Ralph Paton, I understand,” said the lawyer cautiously.</p>
+			<p>“You are acting on behalf of Captain Ralph Paton, I understand,” said the lawyer cautiously.</p>
 			<p>Poirot shook his head. “Not so. I am acting in the interests of justice. Miss Ackroyd has asked me to investigate the death of her uncle.”</p>
 			<p><abbr>Mr.</abbr> Hammond seemed slightly taken aback. “I cannot seriously believe that Captain Paton can be concerned in this crime,” he said, “however strong the circumstantial evidence against him may be. The mere fact that he was hard pressed for money⁠—”</p>
 			<p>“Was he hard pressed for money?” interpolated Poirot quickly.</p>


### PR DESCRIPTION
There's a typo in some early dialog here, with 'of' substituted for 'on'.