### PR TITLE
Fix minor typo

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -46,7 +46,7 @@
 		<meta id="collection-1" property="belongs-to-collection">Poirot</meta>
 		<meta property="collection-type" refines="#collection-1">series</meta>
 		<meta property="group-position" refines="#collection-1">4</meta>
-		<meta id="collection-2" property="belongs-to-collection">Le Monde‘s 100 Books of the Century</meta>
+		<meta id="collection-2" property="belongs-to-collection">Le Monde’s 100 Books of the Century</meta>
 		<meta property="collection-type" refines="#collection-2">set</meta>
 		<meta property="group-position" refines="#collection-2">49</meta>
 		<dc:description id="description">Poirot comes out of retirement to investigate the murder of a friend.</dc:description>

--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -46,6 +46,9 @@
 		<meta id="collection-1" property="belongs-to-collection">Poirot</meta>
 		<meta property="collection-type" refines="#collection-1">series</meta>
 		<meta property="group-position" refines="#collection-1">4</meta>
+		<meta id="collection-2" property="belongs-to-collection">Le Monde‘s 100 Books of the Century</meta>
+		<meta property="collection-type" refines="#collection-2">set</meta>
+		<meta property="group-position" refines="#collection-2">49</meta>
 		<dc:description id="description">Poirot comes out of retirement to investigate the murder of a friend.</dc:description>
 		<meta id="long-description" property="se:long-description" refines="#description">
 			&lt;p&gt;Hercule Poirot has retired to the English village of King’s Abbot, determined to use his little grey cells in the growing of vegetable marrows. But when Roger Ackroyd, a local businessman and former acquaintance of Poirot’s, is murdered, the man’s niece begs Poirot to investigate in order to clear her fiancé. With Hastings having married and moved to Argentina, Poirot enlists the local doctor to be his assistant and scribe, and the two of them sift through clues to try to discern the ones that will lead them to the killer.&lt;/p&gt;


### PR DESCRIPTION
I curled a quote the wrong way (lint didn't pick that up, maybe that's something to add? To be fair it probably isn't a common error). I'll have to go through the PRs and fix this. 

I was hoping to do this before you merged, but you were too quick! There's an empty merge request before my fix. Is it possible to easily ignore that on your end? Otherwise I can play around with rebasing to get rid of it. 