### PR TITLE
fix a typo: billard -> billiard

### DIFF
--- a/src/epub/text/chapter-6.xhtml
+++ b/src/epub/text/chapter-6.xhtml
@@ -57,7 +57,7 @@
 			<p>He stood off a few steps to judge his effect.</p>
 			<p>“Yes,” I said mildly. “I guessed that.”</p>
 			<p>I do not see why I should be supposed to be totally devoid of intelligence. After all, I read detective stories, and the newspapers, and am a man of quite average ability. If there had been toe marks on the dagger handle, now, that would have been quite a different thing. I would then have registered any amount of surprise and awe.</p>
-			<p>I think the inspector was annoyed with me for declining to get thrilled. He picked up the china mug and invited me to accompany him to the billard room.</p>
+			<p>I think the inspector was annoyed with me for declining to get thrilled. He picked up the china mug and invited me to accompany him to the billiard room.</p>
 			<p>“I want to see if <abbr>Mr.</abbr> Raymond can tell us anything about this dagger,” he explained.</p>
 			<p>Locking the outer door behind us again, we made our way to the billiard room, where we found Geoffrey Raymond. The inspector held up his exhibit.</p>
 			<p>“Ever seen this before, <abbr>Mr.</abbr> Raymond?”</p>


### PR DESCRIPTION
"to the **billard** room." -> "to the **billiard** room."

![Screenshot 2022-08-07 13 21 50](https://user-images.githubusercontent.com/23830955/183284175-f2dfdaee-741c-496d-8050-26e87afc60e9.png)
