### PR TITLE
Update colophon.xhtml

### DIFF
--- a/src/epub/text/colophon.xhtml
+++ b/src/epub/text/colophon.xhtml
@@ -12,7 +12,7 @@
 				<img alt="The Standard Ebooks logo." src="../images/logo.svg" epub:type="z3998:publisher-logo se:image.color-depth.black-on-transparent"/>
 			</header>
 			<p><i epub:type="se:name.publication.book">The Murder of Roger Ackroyd</i><br/>
-			was published in 1927 by<br/>
+			was published in 1926 by<br/>
 			<a href="https://en.wikipedia.org/wiki/Agatha_Christie">Agatha Christie</a>.</p>
 			<p>This ebook was produced for<br/>
 			<a href="https://standardebooks.org">Standard Ebooks</a><br/>


### PR DESCRIPTION
Changed the publication year from 1927 to 1926.

Sources:
- Internet Archive: https://archive.org/details/murderofrogerack0000unse/page/n5/mode/2up

https://archive.org/details/murderofrogerack0000agat/page/n7/mode/2up

https://archive.org/details/murderofrogerack0000agat_g7y3/page/n7/mode/2up